### PR TITLE
🐛 修正危险的待绑定账号查询逻辑

### DIFF
--- a/nonebot_plugin_skland_arksign/command.py
+++ b/nonebot_plugin_skland_arksign/command.py
@@ -6,15 +6,19 @@ from nonebot.adapters import Bot, Event
 from nonebot.permission import SUPERUSER
 from nonebot_plugin_alconna import on_alconna
 from sqlalchemy.ext.asyncio import AsyncSession
+from nonebot_plugin_datastore import get_session
 from nonebot_plugin_saa import Text, PlatformTarget
-from nonebot_plugin_datastore import get_session, create_session
-from nonebot_plugin_session import Session, SessionLevel, extract_session
-from nonebot_plugin_session.model import SessionModel, get_or_add_session_model
+from nonebot_plugin_session import Session, extract_session
 
 from .alc_parser import skland_alc
 from .model import SklandSubscribe
 from .utils import run_sign, cleantext
 from .depends import skland_session_extract
+
+SessionId1 = str
+BindUid = str
+
+wait_bind_dict: dict[SessionId1, BindUid] = {}
 
 skland = on_alconna(
     skland_alc,
@@ -43,6 +47,10 @@ async def add(
     # 判断是否为私信/群聊
 
     # 先添加一个record
+    stmt = select(SklandSubscribe).where(SklandSubscribe.uid == uid)
+    result = await db_session.scalar(stmt)
+    if result:
+        await skland.finish("该UID已经被注册，请检查")
     new_record = SklandSubscribe(user=user_account.dict(), uid=uid, token=token, cred="", note=note)
     db_session.add(new_record)
     await db_session.commit()
@@ -51,9 +59,12 @@ async def add(
     # 这是群聊
     if state.get("is_group"):
         # 把sessionb保存到消息数据库里
-        async with create_session() as db_session:
-            await get_or_add_session_model(event_session, db_session)
-            logger.debug(f"当前会话的Session信息：{event_session.dict()}")
+        if not event_session.id1:
+            await skland.finish("不能从群会话提取私聊id，请使用私聊添加账号")
+        elif exist_bind := wait_bind_dict.get(event_session.id1):
+            await skland.finish(f"已经有一个账号在等待绑定，无法添加新账号！\nUID：{exist_bind}")
+        else:
+            wait_bind_dict[event_session.id1] = uid
 
         await skland.finish(cleantext(f"""
             [森空岛明日方舟签到器]已在群聊{event_session.id2}添加新账号！
@@ -64,11 +75,7 @@ async def add(
     # 这是私信
     else:
         if not token:
-            await skland.finish(cleantext(f"""
-                [森空岛明日方舟签到器]已添加新账号！
-                UID：{uid}
-                备注：{note or "无"}
-                接下来，请你通过`私信`bot /森空岛 bind [该账号对应的token] 来完成定时签到服务！"""))
+            await skland.finish("请提供token！")
 
         await skland.send(cleantext(f"""
                 [森空岛明日方舟签到器]已添加新账号！
@@ -88,55 +95,48 @@ async def bind(
     db_session: AsyncSession = Depends(get_session),
 ):
     logger.debug(f"匹配到的参数：{state}")
+    if not event_session.id1:
+        await skland.finish("不能提取私聊id，请更换私聊方式或者聊天平台")
+    # 先找到私聊用户对应的待绑定账号
+    bind_uid = wait_bind_dict.get(event_session.id1)
+    if not bind_uid:
+        await skland.finish("请先在群聊添加账号，再通过私聊绑定")
 
-    user_account = event_session.get_saa_target()
-    if not user_account:
-        await skland.finish("未能获取到当前会话的可发送用户信息，请检查")
-
-    # 先找到私聊用户对应的群聊Session
-    get_group_session_stmt = select(SessionModel).where(
-        (SessionModel.id1 == event_session.id1) | (SessionModel.level != SessionLevel.LEVEL1)
-    )
-    group_session_list = (await db_session.scalars(get_group_session_stmt)).all()
-    if not group_session_list:
-        await skland.finish("未找到与你对应的群聊Session，请检查")
-    elif group_session_saa_list := [
-        saa_target for group_session in group_session_list if (saa_target := group_session.session.get_saa_target())
-    ]:
-        group_session_dict_list = [saa_target.dict() for saa_target in group_session_saa_list]
-        logger.debug(f"查询到的群聊Session: {group_session_list}")
-        logger.debug(f"查询到的群聊Session对应的用户信息：{group_session_dict_list}")
-    else:
-        await skland.finish("无法获取到对应可发送用户信息，请检查")
-
-    # 再更新SklandSubscribe
-    # 判断group_session_dict_list里是否有与SklandSubscribe匹配的用户
-    get_skland_subscribe_stmt = select(SklandSubscribe).where(SklandSubscribe.user.in_(group_session_dict_list))
-    skd_user: SklandSubscribe | None = (await db_session.scalars(get_skland_subscribe_stmt)).first()
+    # 判断是否有与SklandSubscribe匹配的用户
+    get_skland_subscribe_stmt = select(SklandSubscribe).where(SklandSubscribe.uid == bind_uid)
+    # uid是主键，所以只会有一个
+    skd_user: SklandSubscribe | None = (await db_session.scalars(get_skland_subscribe_stmt)).one_or_none()
     logger.debug(f"查询到的SklandSubscribe：{skd_user}")
     if not skd_user:
         await skland.finish("未能匹配到你在群聊注册的账号，请检查")
     skd_user.token = token
-    await db_session.flush()
+    # 保存到数据库
+    await db_session.commit()
+    await db_session.refresh(skd_user)
+
+    uid = skd_user.uid
+    note = skd_user.note or "无"
+    user = skd_user.user
     logger.debug(f"更新后的SklandSubscribe：{skd_user}")
+
+    # 删除待绑定账号
+    del wait_bind_dict[event_session.id1]
+
     # 发送成功信息（私聊）
     await skland.send(cleantext(f"""
             [森空岛明日方舟签到器]已经为绑定在群聊的游戏账号绑定TOKEN！
-            群聊ID：{skd_user.user}
-            游戏账号UID：{skd_user.uid}
+            群聊：{user}
+            游戏账号UID：{uid}
             TOKEN：{token}
-            备注：{skd_user.note}
+            备注：{note}
             """))
     # 再到群聊通知一下
-    runres = await run_sign(uid=skd_user.uid, token=token)
+    runres = await run_sign(uid=uid, token=token)
     msg = Text(cleantext(f"""
-        [森空岛明日方舟签到器]用户{event_session.id1}已经通过私信绑定账号{skd_user.uid}的token！
+        [森空岛明日方舟签到器]用户{event_session.id1}已经通过私信绑定账号{uid}的token！
         立即执行签到操作完成！
         信息如下：{runres['text']}"""))
-    await msg.send_to(PlatformTarget.deserialize(skd_user.user))
-
-    # 保存到数据库
-    await db_session.commit()
+    await msg.send_to(PlatformTarget.deserialize(user))
 
 
 # 删除功能可以在各处使用
@@ -171,7 +171,7 @@ async def del_(
     await skland.finish(cleantext(f"""
             [森空岛明日方舟签到器]已删除旧账号！
             UID：{uid}
-            备注：{note}
+            备注：{note or "无"}
             """))
 
 
@@ -263,7 +263,7 @@ async def signin(
         await skland.finish("未能使用uid或备注匹配到任何账号，请检查")
 
     sign_res = await run_sign(uid=result.uid, token=result.token)
-    await skland.send(cleantext(f"""
+    await skland.finish(cleantext(f"""
             [森空岛明日方舟签到器]已为账号{result.uid}手动签到！
             信息如下：{sign_res['text']}
             """))

--- a/nonebot_plugin_skland_arksign/command.py
+++ b/nonebot_plugin_skland_arksign/command.py
@@ -135,12 +135,6 @@ async def bind(
         信息如下：{runres['text']}"""))
     await msg.send_to(PlatformTarget.deserialize(skd_user.user))
 
-    # 最后删掉Session数据库里的消息
-    delete_session_stmt = select(SessionModel).where(SessionModel.id1 == event_session.id1)
-    result = (await db_session.scalars(delete_session_stmt)).all()
-    for i in result:
-        await db_session.delete(i)
-    await db_session.flush()
     # 保存到数据库
     await db_session.commit()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-skland-arksign"
-version = "0.5.0"
+version = "0.5.1"
 description = "用于每日定时签到森空岛明日方舟的Nonebot插件"
 authors = [
     {name = "GuGuMur", email = "222153315@qq.com"},


### PR DESCRIPTION
原先的将session存到session插件的数据库中，然后bind完毕后删除所有id1对应的储存的session实在是太危险